### PR TITLE
Handle IPv6 logins and inst behind proxy correctly

### DIFF
--- a/admin/superadmin.php
+++ b/admin/superadmin.php
@@ -306,7 +306,7 @@ $cfg = $currentCfg;
             <table class="alternate-rows">
             <tr><th>timestamp</th><th>IP</th><th>user</th><th>LA</th><th>succ</th><th>userAgent</th></tr>
             <?php
-            $stmt = $db->query( "SELECT logins.timestamp timestamp, INET_NTOA(ip) ip, login, userId, users.name name, sections.name section, success, userAgent FROM logins LEFT JOIN users USING (userId) LEFT JOIN sections USING (sectionId) ORDER BY timestamp DESC LIMIT 50" );
+            $stmt = $db->query( "SELECT logins.timestamp timestamp, ip, login, userId, users.name name, sections.name section, success, userAgent FROM logins LEFT JOIN users USING (userId) LEFT JOIN sections USING (sectionId) ORDER BY timestamp DESC LIMIT 50" );
             while ( $row = $stmt->fetch( PDO::FETCH_OBJ ) ) {
                 echo "<tr><td>{$row->timestamp}</td>
                     <td>{$row->ip}</td>

--- a/inc/ffboka/user.php
+++ b/inc/ffboka/user.php
@@ -170,7 +170,7 @@ class User extends FFBoka {
                 // Regenerate login token
                 $u->createPersistentLogin( $ttl );
                 // Log
-                self::$db->exec( "INSERT INTO logins (ip, login, userId, success, userAgent) VALUES (INET_ATON('{$_SERVER['REMOTE_ADDR']}'), '(token)', '{$row->userId}', 2, '{$_SERVER['HTTP_USER_AGENT']}')" );
+                self::$db->exec( "INSERT INTO logins (ip, login, userId, success, userAgent) VALUES ('" . ( $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ) . "', '(token)', '{$row->userId}', 2, '{$_SERVER['HTTP_USER_AGENT']}')" );
             }
         }
     }

--- a/inc/version.php
+++ b/inc/version.php
@@ -3,4 +3,4 @@
 // is changed. The corresponding SQL code for the change must be stored in
 // resources/db/{$dbVersion}.sql and will be executed on the next invocation of
 // any page.
-$dbVersion = 24;
+$dbVersion = 25;

--- a/resources/db/25.sql
+++ b/resources/db/25.sql
@@ -1,0 +1,7 @@
+-- Change login table to allow for IPv6 addresses
+ALTER TABLE `logins` ADD `ip6` tinytext NOT NULL AFTER `ip`;
+UPDATE `logins` SET ip6 = INET_NTOA(ip);
+ALTER TABLE `logins` DROP `ip`;
+ALTER TABLE `logins` RENAME COLUMN `ip6` TO `ip`;
+
+UPDATE config SET value=25 WHERE name='db-version';


### PR DESCRIPTION
Change table definition for login log to be able to store IPv6 addresses.
Check if $_SERVER[HTTP_X_FORWARDED_FOR] exists, if yes, take this as the remote IP address (behind proxy).